### PR TITLE
Create .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+  - scheme: QRCode


### PR DESCRIPTION
Hi Darren, we spoke about your package in our [Twitter Space](https://twitter.com/i/spaces/1ZkKzbkzajZKv) yesterday and while doing so I noticed that we're not reporting the supported platforms correctly:

<img width="526" alt="CleanShot 2022-05-13 at 15 54 30@2x" src="https://user-images.githubusercontent.com/65520/168299088-3f19c246-7e51-4dcf-8889-b6389a80c394.png">

This is because our build system picks and builds the scheme `QRCode-Package`, which I believe is the wrong one for the platforms that are built via `xcodebuild`.

Via our `.spi.yml` file you can control which scheme we pick. So if you'd like to fix the platform display, just merging this PR should correct this and show a green tick for iOS, tvOS, and watchOS once it's been processed. (Note that default branch changes take 24h to be built, because we collate them. Only releases are built as soon as they happen.)